### PR TITLE
feat: skip response body FFI when body inspection is disabled

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       # renovate: datasource=github-releases depName=corazawaf/libcoraza
-      LIBCORAZA_VERSION: v1.1.0
+      LIBCORAZA_VERSION: v1.4.0
     strategy:
       matrix:
         mpm: [event, prefork]

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     env:
       # renovate: datasource=github-releases depName=corazawaf/libcoraza
-      LIBCORAZA_VERSION: v1.1.0
+      LIBCORAZA_VERSION: v1.4.0
     strategy:
       matrix:
         arch: [amd64, arm64]

--- a/Dockerfile
+++ b/Dockerfile
@@ -265,15 +265,15 @@ RUN { \
     echo '# --- auditlog action with RelevantOnly ---'; \
     echo '<Location "/auditlog-relevant">'; \
     echo '    SecAuditEngine RelevantOnly'; \
-    echo '    SecAuditLogRelevantStatus ".*"'; \
+    echo '    SecAuditLogRelevantStatus "^(?:5|4[0-9][0-35-9])"'; \
     echo '    SecAuditLogParts ABHZ'; \
     echo '    SecAuditLogType Serial'; \
     echo '    SecAuditLog /var/log/coraza/audit/relevant.log'; \
-    echo '    SecRule ARGS:trigger "@streq yes" "id:31010,phase:1,pass,auditlog"'; \
+    echo '    SecRule ARGS:trigger "@streq yes" "id:31010,phase:1,deny,status:403,auditlog"'; \
     echo '</Location>'; \
     echo '<Location "/auditlog-relevant-nolog">'; \
     echo '    SecAuditEngine RelevantOnly'; \
-    echo '    SecAuditLogRelevantStatus ".*"'; \
+    echo '    SecAuditLogRelevantStatus "^(?:5|4[0-9][0-35-9])"'; \
     echo '    SecAuditLogParts ABHZ'; \
     echo '    SecAuditLogType Serial'; \
     echo '    SecAuditLog /var/log/coraza/audit/relevant-nolog.log'; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN set -eux; \
         bash \
         make
 
-ARG LIBCORAZA_VERSION=v1.1.0
+ARG LIBCORAZA_VERSION=v1.4.0
 
 RUN set -eux; \
     wget https://github.com/corazawaf/libcoraza/tarball/${LIBCORAZA_VERSION} -O /tmp/libcoraza.tar.gz; \

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Same dependency chain as coraza-nginx: coraza (Go) -> libcoraza (C bindings) -> 
 
 ## Build
 
-Requires libcoraza headers at compile time and the shared library at runtime.
+Requires libcoraza >= 1.4.0 headers at compile time and the shared library at runtime.
 The module is not linked against libcoraza -- it loads it via dlopen()
 after fork to avoid Go runtime deadlocks.
 

--- a/src/mod_coraza.h
+++ b/src/mod_coraza.h
@@ -82,6 +82,7 @@ typedef struct {
     int phase4_done;               /* response body processed */
     int logged;                    /* audit log already emitted (prevents double-log) */
     int intervention_triggered;    /* WAF denied the request */
+    int response_body_processable; /* body inspection needed for this tx */
 } coraza_request_ctx_t;
 
 

--- a/src/mod_coraza_dl.c
+++ b/src/mod_coraza_dl.c
@@ -44,6 +44,7 @@ typedef int                  (*fn_coraza_process_response_headers)(coraza_transa
 typedef int                  (*fn_coraza_process_logging)(coraza_transaction_t);
 typedef int                  (*fn_coraza_update_status_code)(coraza_transaction_t, int);
 typedef int                  (*fn_coraza_add_get_args)(coraza_transaction_t, char *, char *);
+typedef int                  (*fn_coraza_is_response_body_processable)(coraza_transaction_t);
 
 /* ------------------------------------------------------------------ */
 /* Static function pointers -- set once by coraza_dl_open()            */
@@ -76,6 +77,7 @@ static fn_coraza_process_response_headers dl_process_response_headers;
 static fn_coraza_process_logging         dl_process_logging;
 static fn_coraza_update_status_code      dl_update_status_code;
 static fn_coraza_add_get_args            dl_add_get_args;
+static fn_coraza_is_response_body_processable dl_is_response_body_processable;
 
 static dynlib_t dl_handle;
 
@@ -143,6 +145,8 @@ coraza_dl_open(server_rec *s)
     DL_SYM(dl_process_logging,          coraza_process_logging);
     DL_SYM(dl_update_status_code,       coraza_update_status_code);
     DL_SYM(dl_add_get_args,             coraza_add_get_args);
+    DL_SYM(dl_is_response_body_processable,
+           coraza_is_response_body_processable);
 
     ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, s,
                  "coraza: %s loaded via dynlib_open",
@@ -315,4 +319,9 @@ int coraza_add_get_args(coraza_transaction_t t, char *name,
                         char *value)
 {
     return dl_add_get_args(t, name, value);
+}
+
+int coraza_is_response_body_processable(coraza_transaction_t t)
+{
+    return dl_is_response_body_processable(t);
 }

--- a/src/mod_coraza_filter_out.c
+++ b/src/mod_coraza_filter_out.c
@@ -94,6 +94,9 @@ coraza_output_filter(ap_filter_t *f, apr_bucket_brigade *bb)
         coraza_process_response_headers(ctx->transaction, status,
                                         (char *)http_response_ver);
 
+        ctx->response_body_processable =
+            coraza_is_response_body_processable(ctx->transaction);
+
         ret = coraza_process_intervention(ctx->transaction, r, 0);
         if (ret > 0) {
             /* Phase 3 intervention: no data sent yet, generate clean error */
@@ -141,7 +144,7 @@ coraza_output_filter(ap_filter_t *f, apr_bucket_brigade *bb)
             return rv;
         }
 
-        if (len > 0) {
+        if (len > 0 && ctx->response_body_processable) {
             coraza_append_response_body(ctx->transaction,
                                         (unsigned char *)data, (int)len);
 


### PR DESCRIPTION
Use `coraza_is_response_body_processable()` (libcoraza >= 1.4.0) to skip `coraza_append_response_body()` when body inspection is not needed. Avoids unnecessary Go FFI overhead on large responses.

Not a functional fix — Apache doesn't hang like nginx (#7) — but a performance improvement. Phase 4 rule evaluation always runs regardless, as phase 4 rules can match non-body variables.

Requires libcoraza >= 1.4.0.

cc @fzipi @jptosso

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Response bodies are processed only when needed, reducing unnecessary work and improving throughput.
  * Test configuration tightened: relevant-audit selection now targets 4xx/5xx responses and a test rule outcome was changed to deny with a 403 status.

* **Documentation**
  * Build prerequisites updated to require libcoraza >= 1.4.0.

* **Chores**
  * CI/build workflows and image build updated to target the newer libcoraza.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->