### PR TITLE
feat: add go-ftw e2e tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,9 @@ jobs:
             --container=coraza-apache-${{ matrix.mpm }}
 
       - name: Install go-ftw
-        run: go install github.com/coreruleset/go-ftw@latest
+        run: |
+          # renovate: depName=coreruleset/go-ftw datasource=github-releases
+          go install github.com/coreruleset/go-ftw@v2.1.0
 
       - name: Run go-ftw tests
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,19 @@ jobs:
             --mpm=${{ matrix.mpm }} \
             --container=coraza-apache-${{ matrix.mpm }}
 
+      - name: Install go-ftw
+        run: go install github.com/coreruleset/go-ftw@latest
+
+      - name: Run go-ftw tests
+        run: |
+          cat > /tmp/.ftw.yaml <<'EOF'
+          testoverride:
+            input:
+              dest_addr: "127.0.0.1"
+              port: 8888
+          EOF
+          ~/go/bin/go-ftw run --cloud --config /tmp/.ftw.yaml -d tests/ftw/
+
       - name: Extract module artifact
         if: matrix.mpm == 'event'
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install go-ftw
         run: |
           # renovate: depName=coreruleset/go-ftw datasource=github-releases
-          go install github.com/coreruleset/go-ftw@v2.1.0
+          go install github.com/coreruleset/go-ftw/v2@v2.1.0
 
       - name: Run go-ftw tests
         run: |

--- a/tests/ftw/attacks-rce.yaml
+++ b/tests/ftw/attacks-rce.yaml
@@ -1,0 +1,64 @@
+---
+meta:
+  author: "coraza"
+  description: "Remote Code Execution (RCE) detection across HTTP methods"
+
+rule_id: 932100
+tests:
+  - test_title: "GET RCE: command injection"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/?cmd=;cat%20/etc/passwd"
+        output:
+          status: 403
+
+  - test_title: "POST RCE: shell command"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "POST"
+          uri: "/"
+          data: "cmd=;cat /etc/passwd"
+        output:
+          status: 403
+
+  - test_title: "POST RCE: pipe command"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "POST"
+          uri: "/"
+          data: "cmd=|ls -la"
+        output:
+          status: 403
+
+  - test_title: "PUT RCE: shell command"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "PUT"
+          uri: "/"
+          data: "cmd=;cat /etc/passwd"
+        output:
+          status: 403
+
+  - test_title: "DELETE RCE: shell command"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "DELETE"
+          uri: "/"
+          data: "cmd=;cat /etc/passwd"
+        output:
+          status: 403

--- a/tests/ftw/attacks-sqli.yaml
+++ b/tests/ftw/attacks-sqli.yaml
@@ -1,0 +1,120 @@
+---
+meta:
+  author: "coraza"
+  description: "SQL Injection detection across HTTP methods"
+
+rule_id: 942100
+tests:
+  - test_title: "GET SQLi: OR 1=1"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/?id=1%20OR%201%3D1"
+        output:
+          status: 403
+
+  - test_title: "GET SQLi: UNION SELECT"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/?id=1%20UNION%20SELECT%201,2,3"
+        output:
+          status: 403
+
+  - test_title: "GET normal request passes"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/"
+        output:
+          status: 200
+
+  - test_title: "POST SQLi: OR 1=1"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "POST"
+          uri: "/"
+          data: "id=1 OR 1=1"
+        output:
+          status: 403
+
+  - test_title: "POST SQLi: UNION SELECT"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "POST"
+          uri: "/"
+          data: "id=1 UNION SELECT 1,2,3"
+        output:
+          status: 403
+
+  - test_title: "POST SQLi: DROP TABLE"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "POST"
+          uri: "/"
+          data: "q=1;DROP TABLE users"
+        output:
+          status: 403
+
+  - test_title: "POST normal form passes"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "POST"
+          uri: "/"
+          data: "name=john&age=30"
+        output:
+          status: 200
+
+  - test_title: "POST normal JSON passes"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/json"
+          method: "POST"
+          uri: "/"
+          data: '{"user":"john","action":"login"}'
+        output:
+          status: 200
+
+  - test_title: "PUT SQLi: OR 1=1"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "PUT"
+          uri: "/"
+          data: "id=1 OR 1=1"
+        output:
+          status: 403
+
+  - test_title: "DELETE SQLi: OR 1=1"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "DELETE"
+          uri: "/"
+          data: "id=1 OR 1=1"
+        output:
+          status: 403

--- a/tests/ftw/attacks-xss.yaml
+++ b/tests/ftw/attacks-xss.yaml
@@ -1,0 +1,74 @@
+---
+meta:
+  author: "coraza"
+  description: "Cross-Site Scripting (XSS) detection across HTTP methods"
+
+rule_id: 941100
+tests:
+  - test_title: "GET XSS: script tag"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/?q=%3Cscript%3Ealert(1)%3C/script%3E"
+        output:
+          status: 403
+
+  - test_title: "GET XSS: img onerror"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/?q=%3Cimg%20src%3Dx%20onerror%3Dalert(1)%3E"
+        output:
+          status: 403
+
+  - test_title: "POST XSS: script tag"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "POST"
+          uri: "/"
+          data: "q=<script>alert(1)</script>"
+        output:
+          status: 403
+
+  - test_title: "POST XSS: img onerror"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "POST"
+          uri: "/"
+          data: "q=<img src=x onerror=alert(1)>"
+        output:
+          status: 403
+
+  - test_title: "PUT XSS: script tag"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "PUT"
+          uri: "/"
+          data: "q=<script>alert(1)</script>"
+        output:
+          status: 403
+
+  - test_title: "DELETE XSS: script tag"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "DELETE"
+          uri: "/"
+          data: "q=<script>alert(1)</script>"
+        output:
+          status: 403

--- a/tests/ftw/config-merge.yaml
+++ b/tests/ftw/config-merge.yaml
@@ -1,0 +1,48 @@
+---
+meta:
+  author: "coraza"
+  description: "Config merging and override tests"
+
+rule_id: 20010
+tests:
+  - test_title: "Engine off: SQLi passes"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/merge-engine-off?id=1%20OR%201%3D1"
+        output:
+          status: 200
+
+  - test_title: "Body access off: POST SQLi passes"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "POST"
+          uri: "/merge-bodyaccess-off/"
+          data: "id=1 OR 1=1"
+        output:
+          status: 200
+
+  - test_title: "Inherited location: local rule blocks"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/merge-inherited?localonly=yes"
+        output:
+          status: 403
+
+  - test_title: "Inherited location: CRS still active"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/merge-inherited?id=1%20OR%201%3D1"
+        output:
+          status: 403

--- a/tests/ftw/phases.yaml
+++ b/tests/ftw/phases.yaml
@@ -1,0 +1,74 @@
+---
+meta:
+  author: "coraza"
+  description: "Phase 1 and 2 rule evaluation"
+
+rule_id: 20001
+tests:
+  - test_title: "Phase 1: block 403"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/phase1?action=block403"
+        output:
+          status: 403
+
+  - test_title: "Phase 1: normal passes"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/phase1?action=safe"
+        output:
+          status: 200
+
+  - test_title: "Phase 2: deny on body"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "POST"
+          uri: "/phase2"
+          data: "PHASE2ATTACK"
+        output:
+          status: 403
+
+  - test_title: "Phase 2: clean body passes"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "POST"
+          uri: "/phase2"
+          data: "cleandata"
+        output:
+          status: 200
+
+  - test_title: "Phase 2: PUT deny on body"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "PUT"
+          uri: "/phase2"
+          data: "PHASE2ATTACK"
+        output:
+          status: 403
+
+  - test_title: "Phase 2: DELETE deny on body"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+            Content-Type: "application/x-www-form-urlencoded"
+          method: "DELETE"
+          uri: "/phase2"
+          data: "PHASE2ATTACK"
+        output:
+          status: 403

--- a/tests/ftw/redirects.yaml
+++ b/tests/ftw/redirects.yaml
@@ -1,0 +1,46 @@
+---
+meta:
+  author: "coraza"
+  description: "Redirect and block status code tests"
+
+rule_id: 20701
+tests:
+  - test_title: "Redirect 302"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/redirect-302?target=redirect"
+        output:
+          status: 302
+
+  - test_title: "Redirect 301"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/redirect-301?target=redirect"
+        output:
+          status: 301
+
+  - test_title: "Block 401"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/deny-401?action=block"
+        output:
+          status: 401
+
+  - test_title: "Redirect: no match passes"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/redirect-302?target=safe"
+        output:
+          status: 200

--- a/tests/ftw/scoring.yaml
+++ b/tests/ftw/scoring.yaml
@@ -1,0 +1,56 @@
+---
+meta:
+  author: "coraza"
+  description: "Anomaly scoring tests"
+
+rule_id: 20199
+tests:
+  - test_title: "Absolute scoring: score=1 passes"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/scoring-absolute?what=badarg1"
+        output:
+          status: 200
+
+  - test_title: "Absolute scoring: score=2 blocks"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/scoring-absolute?what=badarg2"
+        output:
+          status: 403
+
+  - test_title: "Iterative scoring: 1 arg passes"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/scoring-iterative?arg1=badarg1"
+        output:
+          status: 200
+
+  - test_title: "Iterative scoring: 2 args passes"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/scoring-iterative?arg1=badarg1&arg2=badarg2"
+        output:
+          status: 200
+
+  - test_title: "Iterative scoring: 3 args blocks"
+    stages:
+      - input:
+          headers:
+            Host: "localhost"
+          method: "GET"
+          uri: "/scoring-iterative?arg1=badarg1&arg2=badarg2&arg3=badarg3"
+        output:
+          status: 403


### PR DESCRIPTION
Add 40 go-ftw tests running after the existing integration test suite (test.sh). Tests cover attack detection (SQLi, XSS, RCE), phase evaluation, redirects, scoring, and config merging.

Tests run in cloud mode (HTTP status checks only). Same test files as coraza-nginx PR (corazawaf/coraza-nginx#43).

Note: coraza-caddy already runs the full CRS regression test suite via go-ftw. Should we do the same here, or are these custom tests enough for now?

cc @fzipi @jptosso

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for security vulnerability detection including RCE, SQL injection, and XSS attacks
  * Added test suites for application behavior validation including phase evaluation, config merging, redirect handling, and anomaly scoring

* **Chores**
  * Enhanced CI/CD pipeline with additional testing framework integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->