### PR TITLE
ci: add full CRS regression tests via go-ftw

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,14 @@ jobs:
           EOF
           ~/go/bin/go-ftw run --cloud --config /tmp/.ftw.yaml -d tests/ftw/
 
+      - name: Run CRS regression tests
+        run: |
+          # renovate: datasource=github-releases depName=coreruleset/coreruleset
+          CRS_VERSION="4.25.0"
+          curl -fSL "https://github.com/coreruleset/coreruleset/archive/refs/tags/v${CRS_VERSION}.tar.gz" -o /tmp/crs.tar.gz
+          tar -xzf /tmp/crs.tar.gz -C /tmp
+          ~/go/bin/go-ftw run --cloud --config tests/ftw-crs.yml -d /tmp/coreruleset-${CRS_VERSION}/tests/regression/tests/
+
       - name: Extract module artifact
         if: matrix.mpm == 'event'
         run: |

--- a/tests/ftw-crs.yml
+++ b/tests/ftw-crs.yml
@@ -1,0 +1,13 @@
+testoverride:
+  input:
+    dest_addr: "127.0.0.1"
+    port: 8888
+  ignore:
+    # Imported from coraza upstream testing + Apache-specific
+    920100-4: 'Invalid uri, coraza not reached'
+    920100-5: 'Invalid uri, coraza not reached'
+    920620-1: 'To be investigated'
+    920640-4: 'To be investigated'
+    921250-1: 'Expected to match $Version in cookies, failing also in upstream'
+    921250-2: 'Expected to match $Version in cookies, failing also in upstream'
+    933120-2: 'To be investigated: match_regex value might be ModSec specific'


### PR DESCRIPTION
## Summary
- Run the full CRS 4.25 regression test suite against Apache+Coraza using go-ftw in cloud mode
- Reuses the existing Docker container and go-ftw setup from CI
- 7 tests ignored (same as coraza-caddy upstream ignore list + 2 Apache-specific)

## Test plan
- CI passes on both event and prefork MPM

cc @jcchavezs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added Coraza Rule Set regression tests to the continuous integration pipeline, executed automatically after standard test runs
  * Configured test parameters for CRS compatibility validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->