### PR TITLE
Document PPA install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@ Apache HTTPD module for the Coraza WAF engine, using libcoraza (C bindings).
 
 Same dependency chain as coraza-nginx: coraza (Go) -> libcoraza (C bindings) -> this module.
 
+## Install from PPA (Ubuntu)
+
+Prebuilt packages are available from a Launchpad PPA:
+https://launchpad.net/~pierrepomes/+archive/ubuntu/coraza-apache
+
+```shell
+sudo add-apt-repository ppa:pierrepomes/coraza-apache
+sudo apt update
+sudo apt install libapache2-mod-coraza
+```
+
+This pulls in libcoraza automatically. Built for Ubuntu 22.04 (jammy), 24.04 (noble), 25.10 (questing), 26.04 (resolute) and 26.10 (stonking).
+
 ## Build
 
 Requires libcoraza >= 1.4.0 headers at compile time and the shared library at runtime.


### PR DESCRIPTION
Adds an "Install from PPA (Ubuntu)" section documenting the Launchpad PPA and apt install steps.