### PR TITLE
Keep libcoraza loaded for the process lifetime

### DIFF
--- a/src/mod_coraza_dl.c
+++ b/src/mod_coraza_dl.c
@@ -156,17 +156,23 @@ coraza_dl_open(server_rec *s)
 }
 
 /* ------------------------------------------------------------------ */
-/* Public: unload libcoraza.so                                         */
+/* Public: keep libcoraza.so loaded until the process exits            */
+/*                                                                     */
+/* libcoraza embeds a Go runtime, and a Go runtime cannot be safely    */
+/* unloaded with dlclose(): its signal handlers, GC threads and TLS    */
+/* blocks stay registered, so unloading the .so leaves dangling        */
+/* pointers and crashes on teardown.  This runs from the child-pool    */
+/* cleanup (coraza_child_exit), which fires on worker shutdown and on  */
+/* graceful restart, so we must not unload here -- leave the handle in */
+/* place and let normal process exit reclaim it.                       */
 /* ------------------------------------------------------------------ */
 
 void
 coraza_dl_close(server_rec *s)
 {
     if (dl_handle != NULL) {
-        dynlib_close(dl_handle);
-        dl_handle = NULL;
-        ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, s,
-                     "coraza: %s unloaded",
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, s,
+                     "coraza: %s left loaded for process lifetime",
                      CORAZA_DYNLIB_BASENAME DYNLIB_EXT);
     }
 }


### PR DESCRIPTION
coraza_dl_close() runs from the child-pool cleanup (coraza_child_exit),
so it fires on every worker shutdown and graceful restart. It called
dynlib_close() on libcoraza — but libcoraza embeds a Go runtime, and a
Go runtime cannot be safely unloaded via dlclose(): its GC threads,
signal handlers and TLS blocks stay registered, so unloading the .so
leaves dangling pointers and crashes on teardown. Keeping the handle for
the process lifetime is the documented-safe pattern for cgo libraries.

This mirrors the same fix in coraza-nginx (corazawaf/coraza-nginx#64).
Verified the module still builds cleanly against apache2/apr.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when closing the module by keeping the shared library loaded for the lifetime of the process.
  * Prevented unsafe unloading behavior that could cause shutdown/runtime issues.
  * Added clearer debug logging indicating the library will remain loaded after close.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->