### PR TITLE
fix: report REQUEST_PROTOCOL in slash-delimited form

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -168,6 +168,10 @@ RUN { \
     echo '<Location "/phase2">'; \
     echo '    SecRule REQUEST_BODY "@contains PHASE2ATTACK" "id:20002,phase:2,deny,status:403,log"'; \
     echo '</Location>'; \
+    echo '# --- Request protocol (slash-delimited REQUEST_PROTOCOL) ---'; \
+    echo '<Location "/protocol-check">'; \
+    echo '    SecRule REQUEST_PROTOCOL "@streq HTTP/1.1" "id:20800,phase:1,deny,status:403,log"'; \
+    echo '</Location>'; \
     echo '# --- Config merging ---'; \
     echo '<Location "/merge-engine-off">'; \
     echo '    SecRuleEngine Off'; \

--- a/src/mod_coraza_phase1.c
+++ b/src/mod_coraza_phase1.c
@@ -81,21 +81,24 @@ coraza_post_read_request(request_rec *r)
     {
         const char *http_version;
 
+        /* Coraza expects the protocol in slash-delimited form (e.g. "HTTP/1.1"),
+         * matching REQUEST_PROTOCOL; passing a bare "1.1" makes protocol rules
+         * miss. */
         switch (r->proto_num) {
         case HTTP_VERSION(0, 9):
-            http_version = "0.9";
+            http_version = "HTTP/0.9";
             break;
         case HTTP_VERSION(1, 0):
-            http_version = "1.0";
+            http_version = "HTTP/1.0";
             break;
         case HTTP_VERSION(1, 1):
-            http_version = "1.1";
+            http_version = "HTTP/1.1";
             break;
         case HTTP_VERSION(2, 0):
-            http_version = "2.0";
+            http_version = "HTTP/2.0";
             break;
         default:
-            http_version = "1.1";
+            http_version = "HTTP/1.1";
             break;
         }
 

--- a/test.sh
+++ b/test.sh
@@ -216,6 +216,24 @@ check_vhost() {
     fi
 }
 
+# Like check, but forwards extra curl args (e.g. --http1.0) so a test can
+# control the request line. desc/url/expected first; remaining args go to curl.
+check_curl() {
+    desc="$1"
+    url="$2"
+    expected="$3"
+    shift 3
+
+    code=$(curl -s -o /dev/null -w "%{http_code}" "$@" "$url")
+    if [ "$code" = "$expected" ]; then
+        printf "  PASS  %s -> %s\n" "$desc" "$code"
+        PASS=$((PASS + 1))
+    else
+        printf "  FAIL  %s -> %s (expected %s)\n" "$desc" "$code" "$expected"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
 echo "Coraza WAF test suite"
 echo "Target: $URL"
 
@@ -330,6 +348,12 @@ check "Phase 1: deny on ARGS"         "$URL/phase1?action=block403"             
 check "Phase 1: pass clean"           "$URL/phase1?action=safe"                   200
 check_post "Phase 2: deny on body"    "$URL/phase2" "PHASE2ATTACK"                403
 check_post "Phase 2: pass clean"      "$URL/phase2" "cleandata"                   200
+echo ""
+
+echo "--- Request protocol tests ---"
+# REQUEST_PROTOCOL must reach Coraza slash-delimited ("HTTP/1.1"), not bare "1.1".
+check_curl "Protocol: HTTP/1.1 matches REQUEST_PROTOCOL" "$URL/protocol-check" 403
+check_curl "Protocol: HTTP/1.0 does not match"           "$URL/protocol-check" 200 --http1.0
 echo ""
 
 echo "--- Response phase tests (3+4) ---"


### PR DESCRIPTION
Ports the coraza-nginx #83 protocol-format fix to the Apache module.

**Bug:** `mod_coraza_phase1.c` passed a bare version string (`"1.1"`, `"2.0"`) to `coraza_process_uri`, but Coraza expects `REQUEST_PROTOCOL` slash-delimited (`"HTTP/1.1"`), so `REQUEST_PROTOCOL` rules never match.

**Fix:** emit `"HTTP/x.y"` for each version.

**Test:** new `/protocol-check` Location (`SecRule REQUEST_PROTOCOL "@streq HTTP/1.1" ... deny`) plus a small `check_curl` helper that forwards curl args. Verified red→green on an event-MPM build:
- without the fix: `HTTP/1.1 → 200` (rule misses) — test fails
- with the fix: `HTTP/1.1 → 403`, and `--http1.0 → 200` (proves the value is read, not hard-denied)
- full suite **134/0**

First of the Phase-1 hardening ports; nginx reference behaviour in `t/coraza-h3-protocol.t`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved request protocol detection to consistently recognize HTTP versions using standard protocol notation.
  - Added validation for protocol-specific rules, ensuring HTTP/1.1 requests are handled correctly while HTTP/1.0 requests remain unaffected.

- **Tests**
  - Added coverage for request protocol matching, including HTTP/1.1 and HTTP/1.0 scenarios.
  - Added support for testing requests with customized protocol details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->