### PR TITLE
harden: sanitize control bytes in synthesized Location header

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -161,6 +161,10 @@ RUN { \
     echo '<Location "/redirect-301">'; \
     echo '    SecRule ARGS:target "@streq redirect" "id:20702,phase:1,status:301,log,redirect:http://www.coraza.io"'; \
     echo '</Location>'; \
+    echo '# Clean path+query target: sanitizer must pass it byte-for-byte (no over-truncation)'; \
+    echo '<Location "/redirect-clean-path">'; \
+    echo '    SecRule ARGS:target "@streq redirect" "id:20703,phase:1,status:302,log,redirect:http://example.org/clean/path?a=b"'; \
+    echo '</Location>'; \
     echo '# --- Per-phase testing ---'; \
     echo '<Location "/phase1">'; \
     echo '    SecRule ARGS:action "@streq block403" "id:20001,phase:1,deny,status:403,log"'; \

--- a/src/mod_coraza.c
+++ b/src/mod_coraza.c
@@ -136,7 +136,35 @@ coraza_process_intervention(coraza_transaction_t transaction,
         }
 
         if (intervention->data != NULL) {
-            apr_table_set(r->headers_out, "Location", intervention->data);
+            /*
+             * Defense-in-depth against HTTP response splitting / header
+             * injection. If a rule ever builds the redirect target from
+             * client-controlled data (macro expansion of a request variable),
+             * intervention->data could carry CR/LF or other control bytes.
+             * Truncate the Location at the first C0 control character or DEL
+             * (a legitimate URL carries none unencoded). libcoraza 1.4 does
+             * not macro-expand redirect targets today, so this future-proofs
+             * against a dynamic source at negligible cost.
+             */
+            const char *loc = intervention->data;
+            apr_size_t  len = strlen(loc);
+            apr_size_t  safe = 0;
+
+            while (safe < len &&
+                   (unsigned char)loc[safe] >= 0x20 &&
+                   (unsigned char)loc[safe] != 0x7f) {
+                safe++;
+            }
+
+            if (safe != len) {
+                ap_log_rerror(APLOG_MARK, APLOG_WARNING, 0, r,
+                              "coraza: control character in redirect target; "
+                              "truncating Location to %" APR_SIZE_T_FMT
+                              " byte(s)", safe);
+                loc = apr_pstrmemdup(r->pool, loc, safe);
+            }
+
+            apr_table_set(r->headers_out, "Location", loc);
         }
 
         int status = intervention->status;

--- a/test.sh
+++ b/test.sh
@@ -504,6 +504,7 @@ echo "--- Response header guards ---"
 #   - A clean redirect emits exactly the intended Location, nothing smuggled.
 check_head   "HEAD /: not delayed, returns 200"          "$URL/"                              200
 check_header "Redirect: Location is exactly the target"  "$URL/redirect-302?target=redirect"  "Location" "http://www.coraza.io"
+check_header "Redirect: clean path+query preserved"      "$URL/redirect-clean-path?target=redirect" "Location" "http://example.org/clean/path?a=b"
 check_header "Clean response: no smuggled Set-Cookie"    "$URL/"                              "Set-Cookie" "" "!"
 echo ""
 


### PR DESCRIPTION
Ports coraza-nginx #77.

`coraza_process_intervention` copied `intervention->data` verbatim into the `Location` header on a redirect — a raw CR/LF there would allow HTTP response splitting. Now it truncates at the first control byte (C0 or DEL) and logs a warning; a legitimate URL carries none unencoded.

Defense-in-depth: Coraza's `redirect` action stores its target verbatim (no macro expansion), so `intervention->data` is the static rule string rather than client data — the guard future-proofs against a dynamic redirect source at negligible cost.

Regression guard: a clean path+query redirect passes byte-for-byte (no over-truncation). Full suite 138/0.