### PR TITLE
fix: stream SSE responses instead of buffering them

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,7 +115,11 @@ RUN chmod +x /usr/local/apache2/cgi-bin/sse
 RUN { \
     echo 'LoadModule coraza_module modules/mod_coraza.so'; \
     echo 'LoadModule info_module modules/mod_info.so'; \
-    echo 'LoadModule cgid_module modules/mod_cgid.so'; \
+    if [ "$MPM" = "prefork" ]; then \
+      echo 'LoadModule cgi_module modules/mod_cgi.so'; \
+    else \
+      echo 'LoadModule cgid_module modules/mod_cgid.so'; \
+    fi; \
     echo 'Coraza On'; \
     echo 'CorazaRulesFile /etc/coraza/coraza-waf.conf'; \
     echo 'FallbackResource /index.html'; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,10 +107,15 @@ RUN mkdir -p /var/log/coraza && \
 # Copy WAF rules config
 COPY coraza-waf.conf /etc/coraza/coraza-waf.conf
 
+# SSE test endpoint (streaming CGI) for the header-delay skip test
+COPY tests/cgi-bin/sse /usr/local/apache2/cgi-bin/sse
+RUN chmod +x /usr/local/apache2/cgi-bin/sse
+
 # Apache config: load module, enable coraza with CRS, FallbackResource for test URLs
 RUN { \
     echo 'LoadModule coraza_module modules/mod_coraza.so'; \
     echo 'LoadModule info_module modules/mod_info.so'; \
+    echo 'LoadModule cgid_module modules/mod_cgid.so'; \
     echo 'Coraza On'; \
     echo 'CorazaRulesFile /etc/coraza/coraza-waf.conf'; \
     echo 'FallbackResource /index.html'; \
@@ -175,6 +180,20 @@ RUN { \
     echo '# --- Request protocol (slash-delimited REQUEST_PROTOCOL) ---'; \
     echo '<Location "/protocol-check">'; \
     echo '    SecRule REQUEST_PROTOCOL "@streq HTTP/1.1" "id:20800,phase:1,deny,status:403,log"'; \
+    echo '</Location>'; \
+    echo '# --- SSE streaming: header delay must be skipped (never sends EOS) ---'; \
+    echo 'ScriptAlias "/sse-stream" "/usr/local/apache2/cgi-bin/sse"'; \
+    echo 'ScriptAlias "/sse-nearmiss" "/usr/local/apache2/cgi-bin/sse"'; \
+    echo '<Directory "/usr/local/apache2/cgi-bin">'; \
+    echo '    Require all granted'; \
+    echo '    Options +ExecCGI'; \
+    echo '</Directory>'; \
+    echo '<Location "/sse-stream">'; \
+    echo '    SetEnv SSE_CT "text/event-stream"'; \
+    echo '    SecRule ARGS:attack "@streq 1" "id:20810,phase:1,deny,status:403,log"'; \
+    echo '</Location>'; \
+    echo '<Location "/sse-nearmiss">'; \
+    echo '    SetEnv SSE_CT "text/event-streamx"'; \
     echo '</Location>'; \
     echo '# --- Config merging ---'; \
     echo '<Location "/merge-engine-off">'; \

--- a/src/mod_coraza_filter_out.c
+++ b/src/mod_coraza_filter_out.c
@@ -16,6 +16,49 @@
 #include <string.h>
 
 /*
+ * A streaming response has no meaningful end-of-body: the origin emits events
+ * indefinitely and never sends EOS, so the header delay (which flushes on EOS)
+ * would hold the response headers forever and the client receives nothing.
+ * Detect Server-Sent Events (Content-Type: text/event-stream) so the caller
+ * can skip the delay.
+ *
+ * SECURITY TRADE-OFF: Content-Type is chosen by the upstream, so an origin that
+ * emits text/event-stream opts this response out of the phase-4 header delay.
+ * Phase 4 still RUNS (coraza_process_response_body() is still called) and
+ * phases 1-3 are untouched -- what is lost is only turning a phase-4 match into
+ * a clean error page, because the headers are already on the wire; a late match
+ * degrades to a connection reset. Streaming and full-response WAF buffering are
+ * mutually exclusive by construction.
+ *
+ * The media-type match is strict: "text/event-streamx" and
+ * "text/event-stream junk" do NOT qualify; only end-of-value or optional OWS
+ * followed by ';' (a parameter list, RFC 9110 5.6.3) is accepted.
+ */
+static int
+coraza_is_sse_response(request_rec *r)
+{
+    static const char sse[] = "text/event-stream";
+    const apr_size_t sse_len = sizeof(sse) - 1;
+    const char *ct = r->content_type;
+    apr_size_t i, len;
+
+    if (ct == NULL) {
+        return 0;
+    }
+    len = strlen(ct);
+    if (len < sse_len || strncasecmp(ct, sse, sse_len) != 0) {
+        return 0;
+    }
+    for (i = sse_len; i < len; i++) {
+        if (ct[i] == ' ' || ct[i] == '\t') {
+            continue;
+        }
+        return ct[i] == ';';
+    }
+    return 1;  /* exact "text/event-stream" */
+}
+
+/*
  * Output filter: phases 3 (response headers) and 4 (response body).
  *
  * Implements header delay: buffers all output buckets in a pending brigade
@@ -106,6 +149,20 @@ coraza_output_filter(ap_filter_t *f, apr_bucket_brigade *bb)
             r->status = ret;
             ap_die(ret, r);
             return AP_FILTER_ERROR;
+        }
+
+        /*
+         * SSE / streaming responses: phases 1-3 are done. The body loop below
+         * block-reads every bucket before forwarding the brigade, which drains
+         * a streaming response pipe and holds it until EOS -- an SSE stream
+         * never sends EOS, so the client would receive nothing. Step out of the
+         * filter chain and let the response stream. Phase 4 cannot run on a body
+         * that never ends anyway; this is the same trade-off 101 Switching
+         * Protocols accepts (see coraza_is_sse_response).
+         */
+        if (coraza_is_sse_response(r)) {
+            ap_remove_output_filter(f);
+            return ap_pass_brigade(f->next, bb);
         }
 
         /* Begin header delay — skip for HEAD (no body), subrequests (internal),

--- a/src/mod_coraza_filter_out.c
+++ b/src/mod_coraza_filter_out.c
@@ -23,12 +23,13 @@
  * can skip the delay.
  *
  * SECURITY TRADE-OFF: Content-Type is chosen by the upstream, so an origin that
- * emits text/event-stream opts this response out of the phase-4 header delay.
- * Phase 4 still RUNS (coraza_process_response_body() is still called) and
- * phases 1-3 are untouched -- what is lost is only turning a phase-4 match into
- * a clean error page, because the headers are already on the wire; a late match
- * degrades to a connection reset. Streaming and full-response WAF buffering are
- * mutually exclusive by construction.
+ * emits text/event-stream opts this response out of response-body inspection.
+ * Phases 1-3 are untouched, but phase 4 is SKIPPED for SSE: the caller removes
+ * this filter before the body loop, so coraza_process_response_body() is not
+ * called and the streamed body is not inspected. This is inherent -- a body
+ * that never ends cannot be buffered or evaluated -- and is the same trade-off
+ * 101 Switching Protocols already accepts. Streaming and full-response WAF
+ * buffering are mutually exclusive by construction.
  *
  * The media-type match is strict: "text/event-streamx" and
  * "text/event-stream junk" do NOT qualify; only end-of-value or optional OWS

--- a/test.sh
+++ b/test.sh
@@ -309,11 +309,21 @@ check_stream() {
     pattern="$3"
     expect="$4"   # present | absent
 
-    body=$(curl -sN --max-time 4 "$url" 2>/dev/null)
+    # Capture body + final HTTP code. A streamed response yields the pattern
+    # (code 200); a delayed/buffered response sends no headers and curl times
+    # out with code 000. An actual error (4xx/5xx) is neither -- so "absent"
+    # requires the timeout (000), not merely an empty body, to avoid an HTTP
+    # error masquerading as a correctly-delayed stream.
+    out=$(curl -sN --max-time 4 -w '\n%{http_code}' "$url" 2>/dev/null)
+    code=$(printf '%s\n' "$out" | tail -1)
+    body=$(printf '%s\n' "$out" | sed '$d')
+
     if printf '%s' "$body" | grep -q "$pattern"; then
         got=present
+    elif [ "$code" = "000" ]; then
+        got=absent           # held/delayed: no headers arrived within the window
     else
-        got=absent
+        got="error(code=$code)"
     fi
 
     if [ "$got" = "$expect" ]; then

--- a/test.sh
+++ b/test.sh
@@ -300,6 +300,31 @@ check_curl() {
     fi
 }
 
+# Fetch a streaming endpoint with a short timeout and assert whether a pattern
+# arrived. "present" = the stream reached the client (header delay was skipped);
+# "absent" = nothing streamed within the window (still buffered/delayed).
+check_stream() {
+    desc="$1"
+    url="$2"
+    pattern="$3"
+    expect="$4"   # present | absent
+
+    body=$(curl -sN --max-time 4 "$url" 2>/dev/null)
+    if printf '%s' "$body" | grep -q "$pattern"; then
+        got=present
+    else
+        got=absent
+    fi
+
+    if [ "$got" = "$expect" ]; then
+        printf "  PASS  %s -> %s\n" "$desc" "$got"
+        PASS=$((PASS + 1))
+    else
+        printf "  FAIL  %s -> %s (expected %s)\n" "$desc" "$got" "$expect"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
 echo "Coraza WAF test suite"
 echo "Target: $URL"
 
@@ -427,6 +452,15 @@ check "Phase 3: deny on Content-Type"       "$URL/phase3"                       
 check "Phase 3: pass no match"              "$URL/phase3-pass"                     200
 check "Phase 4: deny on body content"       "$URL/phase4"                          403
 check "Phase 4: pass no match"              "$URL/phase4-pass"                     200
+echo ""
+
+echo "--- SSE streaming (header-delay skip) ---"
+# text/event-stream never sends EOS; the header delay must be skipped or the
+# client receives nothing. Near-miss media types must stay delayed, and a
+# phase-1 rule must still block (the exemption must not become a WAF bypass).
+check_stream "SSE: stream reaches client (not delayed)"   "$URL/sse-stream"          "data: tick" present
+check_stream "SSE near-miss: text/event-streamx delayed"  "$URL/sse-nearmiss"        "data: tick" absent
+check_curl   "SSE: phase-1 rule still blocks (no bypass)" "$URL/sse-stream?attack=1" 403 --max-time 5
 echo ""
 
 echo "--- Config merging tests ---"

--- a/tests/cgi-bin/sse
+++ b/tests/cgi-bin/sse
@@ -1,0 +1,16 @@
+#!/bin/sh
+# SSE test endpoint for the header-delay skip test.
+#
+# Streams Content-Type: text/event-stream (or the value of SSE_CT, used to
+# emit a near-miss media type) and then emits events roughly once a second
+# WITHOUT ever sending end-of-stream. Each line is written by a separate
+# /usr/bin/printf process so it is flushed to Apache immediately -- shell
+# builtins would buffer and defeat the streaming the test relies on.
+/usr/bin/printf 'Content-Type: %s\r\n\r\n' "${SSE_CT:-text/event-stream}"
+
+i=0
+while [ "$i" -lt 30 ]; do
+    /usr/bin/printf 'data: tick %s\n\n' "$i"
+    i=$((i + 1))
+    sleep 1
+done

--- a/tests/cgi-bin/sse
+++ b/tests/cgi-bin/sse
@@ -8,8 +8,11 @@
 # builtins would buffer and defeat the streaming the test relies on.
 /usr/bin/printf 'Content-Type: %s\r\n\r\n' "${SSE_CT:-text/event-stream}"
 
+# Endless: never send EOS. Apache terminates the CGI when the client
+# disconnects (the next printf gets SIGPIPE), so the process is reaped within
+# ~1s of the test's curl --max-time cutoff.
 i=0
-while [ "$i" -lt 30 ]; do
+while :; do
     /usr/bin/printf 'data: tick %s\n\n' "$i"
     i=$((i + 1))
     sleep 1


### PR DESCRIPTION
Ports coraza-nginx #82. An SSE (`text/event-stream`) response never sends EOS, so the output filter buffered it forever and the client got nothing.

On a strict `text/event-stream` match, the filter now steps out of the chain after phase 3 and lets the response stream. Phases 1-3 still run; phase-4 body inspection is skipped for SSE (an endless body can't be buffered) — same trade-off as 101 Switching Protocols.

Test (streaming CGI, both MPMs): the stream reaches the client (without the fix it hangs), a near-miss `text/event-streamx` stays delayed, and a phase-1 rule still blocks. Suite 141/0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Server-Sent Events (SSE) responses to stream promptly without waiting for the connection to close.
  * Added SSE test endpoints that continuously deliver event data.

* **Bug Fixes**
  * Prevented response buffering from blocking indefinitely for long-lived SSE connections.
  * Preserved request blocking rules while allowing valid SSE streams to pass through.

* **Tests**
  * Added coverage for valid SSE content types, near-miss content types, streaming behavior, and request filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->