### PR TITLE
fix: cap delayed response-body buffering to bound worker memory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,6 +110,8 @@ COPY coraza-waf.conf /etc/coraza/coraza-waf.conf
 # SSE test endpoint (streaming CGI) for the header-delay skip test
 COPY tests/cgi-bin/sse /usr/local/apache2/cgi-bin/sse
 RUN chmod +x /usr/local/apache2/cgi-bin/sse
+COPY tests/cgi-bin/bulk /usr/local/apache2/cgi-bin/bulk
+RUN chmod +x /usr/local/apache2/cgi-bin/bulk
 
 # Apache config: load module, enable coraza with CRS, FallbackResource for test URLs
 RUN { \
@@ -188,6 +190,7 @@ RUN { \
     echo '# --- SSE streaming: header delay must be skipped (never sends EOS) ---'; \
     echo 'ScriptAlias "/sse-stream" "/usr/local/apache2/cgi-bin/sse"'; \
     echo 'ScriptAlias "/sse-nearmiss" "/usr/local/apache2/cgi-bin/sse"'; \
+    echo 'ScriptAlias "/bulk-delayed" "/usr/local/apache2/cgi-bin/bulk"'; \
     echo '<Directory "/usr/local/apache2/cgi-bin">'; \
     echo '    Require all granted'; \
     echo '    Options +ExecCGI'; \

--- a/src/mod_coraza.h
+++ b/src/mod_coraza.h
@@ -72,10 +72,23 @@ typedef struct {
 } coraza_server_conf_t;
 
 
+/*
+ * Cap on how much response body is buffered while the header delay holds the
+ * response for phase-4 inspection. A large download or an open-ended stream
+ * would otherwise accumulate without limit and inflate worker memory. Once the
+ * buffered body passes this cap the headers and everything buffered so far are
+ * flushed and the remainder streams through. Overridable at build time with
+ * -DCORAZA_MAX_DELAYED_BODY=<bytes>.
+ */
+#ifndef CORAZA_MAX_DELAYED_BODY
+#define CORAZA_MAX_DELAYED_BODY (1024 * 1024)   /* 1 MiB */
+#endif
+
 /* Per-request context */
 typedef struct {
     coraza_transaction_t  transaction;
     apr_bucket_brigade   *pending_brigade;  /* buffered body for header delay */
+    apr_size_t pending_len;        /* bytes buffered while headers are delayed */
     int headers_delayed;           /* response held back pending body inspection */
     int phase2_done;               /* request body processed */
     int phase3_done;               /* response headers processed */

--- a/src/mod_coraza_filter_out.c
+++ b/src/mod_coraza_filter_out.c
@@ -220,6 +220,11 @@ coraza_output_filter(ap_filter_t *f, apr_bucket_brigade *bb)
                               APR_SIZE_T_FMT " bytes; flushing headers early",
                               (apr_size_t) CORAZA_MAX_DELAYED_BODY);
                 ctx->headers_delayed = 0;
+                /* Step out of the chain so the remainder truly streams through
+                 * uninspected -- otherwise the body loop keeps inspecting later
+                 * chunks and a post-flush intervention would drop an in-flight
+                 * brigade, truncating a response the client is already reading. */
+                ap_remove_output_filter(f);
                 APR_BRIGADE_PREPEND(bb, ctx->pending_brigade);
                 ctx->pending_brigade = NULL;
                 return ap_pass_brigade(f->next, bb);

--- a/src/mod_coraza_filter_out.c
+++ b/src/mod_coraza_filter_out.c
@@ -202,6 +202,30 @@ coraza_output_filter(ap_filter_t *f, apr_bucket_brigade *bb)
             return rv;
         }
 
+        /*
+         * Bound worker memory while the header delay holds the response. The
+         * loop reads (and thus buffers) every bucket before forwarding; a large
+         * download or a long stream would otherwise be read into memory in full
+         * before EOS. Once the buffered body passes the cap, stop delaying:
+         * flush the buffered headers + everything read so far and let the rest
+         * stream through uninspected. A later phase-4 match can then no longer
+         * render a clean error page (headers are on the wire) -- the same
+         * trade-off the SSE and 101 Switching Protocols paths accept.
+         */
+        if (ctx->headers_delayed && len > 0) {
+            ctx->pending_len += len;
+            if (ctx->pending_len > CORAZA_MAX_DELAYED_BODY) {
+                ap_log_rerror(APLOG_MARK, APLOG_WARNING, 0, r,
+                              "coraza: delayed response body exceeded %"
+                              APR_SIZE_T_FMT " bytes; flushing headers early",
+                              (apr_size_t) CORAZA_MAX_DELAYED_BODY);
+                ctx->headers_delayed = 0;
+                APR_BRIGADE_PREPEND(bb, ctx->pending_brigade);
+                ctx->pending_brigade = NULL;
+                return ap_pass_brigade(f->next, bb);
+            }
+        }
+
         if (len > 0 && ctx->response_body_processable) {
             coraza_append_response_body(ctx->transaction,
                                         (unsigned char *)data, (int)len);
@@ -268,7 +292,8 @@ coraza_output_filter(ap_filter_t *f, apr_bucket_brigade *bb)
 
     /* Not the last buffer yet */
     if (ctx->headers_delayed) {
-        /* Accumulate into pending brigade during header delay */
+        /* Accumulate into pending brigade during header delay. The total is
+         * bounded by the per-bucket cap check in the phase-4 loop above. */
         APR_BRIGADE_CONCAT(ctx->pending_brigade, bb);
         return APR_SUCCESS;
     }

--- a/test.sh
+++ b/test.sh
@@ -342,12 +342,18 @@ check_size() {
     url="$2"
     expected="$3"
 
-    size=$(curl -s -o /dev/null -w "%{size_download}" --max-time 20 "$url")
-    if [ "$size" = "$expected" ]; then
-        printf "  PASS  %s -> %s bytes\n" "$desc" "$size"
+    result=$(curl -s -o /dev/null -w "%{http_code} %{size_download}" --max-time 20 "$url") || {
+        printf "  FAIL  %s -> curl failed\n" "$desc"
+        FAIL=$((FAIL + 1))
+        return
+    }
+    code=${result%% *}
+    size=${result#* }
+    if [ "$code" = "200" ] && [ "$size" = "$expected" ]; then
+        printf "  PASS  %s -> %s (%s bytes)\n" "$desc" "$code" "$size"
         PASS=$((PASS + 1))
     else
-        printf "  FAIL  %s -> %s bytes (expected %s)\n" "$desc" "$size" "$expected"
+        printf "  FAIL  %s -> %s (%s bytes, expected 200/%s)\n" "$desc" "$code" "$size" "$expected"
         FAIL=$((FAIL + 1))
     fi
 }

--- a/test.sh
+++ b/test.sh
@@ -335,6 +335,37 @@ check_stream() {
     fi
 }
 
+# Assert the number of body bytes downloaded (e.g. a large response arrives
+# intact through the delayed-buffering cap, not truncated).
+check_size() {
+    desc="$1"
+    url="$2"
+    expected="$3"
+
+    size=$(curl -s -o /dev/null -w "%{size_download}" --max-time 20 "$url")
+    if [ "$size" = "$expected" ]; then
+        printf "  PASS  %s -> %s bytes\n" "$desc" "$size"
+        PASS=$((PASS + 1))
+    else
+        printf "  FAIL  %s -> %s bytes (expected %s)\n" "$desc" "$size" "$expected"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Assert a pattern appears in the container's stderr log (Apache error_log).
+check_container_log() {
+    desc="$1"
+    pattern="$2"
+
+    if docker logs "$CONTAINER" 2>&1 | grep -q "$pattern"; then
+        printf "  PASS  %s\n" "$desc"
+        PASS=$((PASS + 1))
+    else
+        printf "  FAIL  %s (pattern '%s' not in container log)\n" "$desc" "$pattern"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
 echo "Coraza WAF test suite"
 echo "Target: $URL"
 
@@ -473,6 +504,13 @@ check_stream "SSE near-miss: text/event-streamx delayed"  "$URL/sse-nearmiss"   
 check_curl   "SSE: phase-1 rule still blocks (no bypass)" "$URL/sse-stream?attack=1" 403 --max-time 5
 echo ""
 
+echo "--- Delayed response cap (bound worker memory) ---"
+# A large delayed response must arrive intact: the cap flushes headers early
+# and streams the rest rather than buffering the whole body (or truncating it).
+check      "Large delayed response: completes 200"    "$URL/bulk-delayed"  200
+check_size "Large delayed response: full 4 MiB body"  "$URL/bulk-delayed"  4194304
+echo ""
+
 echo "--- Config merging tests ---"
 check "Engine off: SQLi passes"       "$URL/merge-engine-off/?id=1%20OR%201=1"    200
 check "Engine off: normal passes"     "$URL/merge-engine-off/"                    200
@@ -565,6 +603,11 @@ echo ""
 
 # Audit log tests (require --container)
 if [ -n "$CONTAINER" ]; then
+    echo "--- Delayed response cap log ---"
+    # The large delayed response above must have tripped the cap's early flush.
+    check_container_log "Cap: flushed delayed headers early"  "flushing headers early"
+    echo ""
+
     echo "--- Audit log tests ---"
     # Generate a blocked request that will appear in audit log
     clear_audit_log

--- a/tests/cgi-bin/bulk
+++ b/tests/cgi-bin/bulk
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Emits a large application/octet-stream body in paced chunks, sending EOS only
+# when it finishes. The short sleep between chunks makes Apache deliver several
+# separate output-filter brigades before EOS -- without pacing the CGI writes
+# fast enough that mod_cgid hands the whole body + EOS to the filter at once,
+# which reaches the has-EOS path before the not-last-buffer cap can trip.
+#
+# Total: 16 * 256 KiB = 4 MiB, comfortably over the 1 MiB cap.
+/usr/bin/printf 'Content-Type: application/octet-stream\r\n\r\n'
+
+i=0
+while [ "$i" -lt 16 ]; do
+    dd if=/dev/zero bs=262144 count=1 2>/dev/null | tr '\0' 'A'
+    i=$((i + 1))
+    sleep 0.2
+done


### PR DESCRIPTION
Ports coraza-nginx #71. While the header delay holds a response for phase-4 inspection, the output filter reads every body bucket into memory before forwarding — a large download or a long stream would buffer without limit.

The filter now tracks the buffered bytes and, once they pass `CORAZA_MAX_DELAYED_BODY` (1 MiB, build-overridable), stops delaying: it flushes the headers + everything buffered so far and lets the rest stream. A later phase-4 match can then no longer render a clean error page (headers are on the wire) — the same trade-off the SSE and 101 paths accept.

The check is per-bucket in the read loop, not just on the pending brigade, so it also bounds a single response drained in one filter pass (e.g. a CGI/streamed source), not only multi-brigade proxied responses.

Test (paced 4 MiB CGI, both MPMs): the response arrives intact (200, full 4 MiB) and the cap logs an early flush; without the fix that flush never happens. Suite 144/0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a bulk-response endpoint for testing and validating large downloads.

* **Bug Fixes**
  * Prevented excessive memory use when inspecting delayed response bodies by enforcing a 1 MiB buffering limit.
  * Automatically forwards responses when the limit is exceeded, allowing large downloads to complete successfully.

* **Tests**
  * Added coverage for delayed 4 MiB responses, complete byte delivery, early header flushing, container logs, and download-size validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->