### PR TITLE
fix: fail closed when body submission or processing fails in Coraza

### DIFF
--- a/src/mod_coraza.h
+++ b/src/mod_coraza.h
@@ -84,6 +84,15 @@ typedef struct {
 #define CORAZA_MAX_DELAYED_BODY (1024 * 1024)   /* 1 MiB */
 #endif
 
+/*
+ * Fail-closed check for the body submit/process calls. The libcoraza ABI this
+ * module targets (< 1.6) returns non-zero on an engine error and 0 on success;
+ * interruptions are reported separately via coraza_intervention(). A non-zero
+ * return therefore means inspection could not complete, and the request or
+ * response must be failed closed rather than passed through uninspected.
+ */
+#define CORAZA_CALL_FAILED(rc) ((rc) != 0)
+
 /* Per-request context */
 typedef struct {
     coraza_transaction_t  transaction;

--- a/src/mod_coraza_body_in.c
+++ b/src/mod_coraza_body_in.c
@@ -50,7 +50,13 @@ coraza_input_filter(ap_filter_t *f, apr_bucket_brigade *bb,
 
         if (APR_BUCKET_IS_EOS(b)) {
             /* End of request body -- process it */
-            coraza_process_request_body(ctx->transaction);
+            if (CORAZA_CALL_FAILED(coraza_process_request_body(ctx->transaction))) {
+                /* Engine error: fail closed rather than pass uninspected. */
+                ctx->intervention_triggered = 1;
+                ctx->phase2_done = 1;
+                ap_remove_input_filter(f);
+                return APR_EGENERAL;
+            }
 
             ret = coraza_process_intervention(ctx->transaction, f->r, 0);
             if (ret > 0) {
@@ -77,8 +83,13 @@ coraza_input_filter(ap_filter_t *f, apr_bucket_brigade *bb,
         }
 
         if (len > 0) {
-            coraza_append_request_body(ctx->transaction,
-                                       (unsigned char *)data, (int)len);
+            if (CORAZA_CALL_FAILED(coraza_append_request_body(ctx->transaction,
+                                       (unsigned char *)data, (int)len))) {
+                ctx->intervention_triggered = 1;
+                ctx->phase2_done = 1;
+                ap_remove_input_filter(f);
+                return APR_EGENERAL;
+            }
 
             /* Check for stream intervention */
             ret = coraza_process_intervention(ctx->transaction, f->r, 0);

--- a/src/mod_coraza_filter_out.c
+++ b/src/mod_coraza_filter_out.c
@@ -60,6 +60,32 @@ coraza_is_sse_response(request_rec *r)
 }
 
 /*
+ * Fail closed on a response-body engine error. If the headers are still delayed
+ * nothing has been sent yet, so a clean 500 error page can be generated;
+ * otherwise the headers are already on the wire and the response is truncated
+ * with a reset. Either way the response is not passed through uninspected.
+ */
+static apr_status_t
+coraza_fail_closed_response(ap_filter_t *f, request_rec *r,
+                            coraza_request_ctx_t *ctx, apr_bucket_brigade *bb)
+{
+    ctx->intervention_triggered = 1;
+    ap_remove_output_filter(f);
+    r->status = HTTP_INTERNAL_SERVER_ERROR;
+
+    if (ctx->headers_delayed) {
+        ctx->headers_delayed = 0;
+        apr_brigade_cleanup(ctx->pending_brigade);
+        apr_brigade_cleanup(bb);
+        ap_die(HTTP_INTERNAL_SERVER_ERROR, r);
+        return AP_FILTER_ERROR;
+    }
+
+    apr_brigade_cleanup(bb);
+    return APR_EGENERAL;
+}
+
+/*
  * Output filter: phases 3 (response headers) and 4 (response body).
  *
  * Implements header delay: buffers all output buckets in a pending brigade
@@ -232,8 +258,11 @@ coraza_output_filter(ap_filter_t *f, apr_bucket_brigade *bb)
         }
 
         if (len > 0 && ctx->response_body_processable) {
-            coraza_append_response_body(ctx->transaction,
-                                        (unsigned char *)data, (int)len);
+            if (CORAZA_CALL_FAILED(coraza_append_response_body(ctx->transaction,
+                                        (unsigned char *)data, (int)len))) {
+                /* Engine error: fail closed rather than stream uninspected. */
+                return coraza_fail_closed_response(f, r, ctx, bb);
+            }
 
             ret = coraza_process_intervention(ctx->transaction, r, 0);
             if (ret > 0) {
@@ -257,7 +286,9 @@ coraza_output_filter(ap_filter_t *f, apr_bucket_brigade *bb)
 
     if (has_eos) {
         /* Process complete response body */
-        coraza_process_response_body(ctx->transaction);
+        if (CORAZA_CALL_FAILED(coraza_process_response_body(ctx->transaction))) {
+            return coraza_fail_closed_response(f, r, ctx, bb);
+        }
 
         ret = coraza_process_intervention(ctx->transaction, r, 0);
         if (ret > 0) {

--- a/src/mod_coraza_phase1.c
+++ b/src/mod_coraza_phase1.c
@@ -164,8 +164,12 @@ coraza_post_read_request(request_rec *r)
         if (ap_should_client_block(r)) {
             /* ap_get_client_block: reads up to N bytes, returns count or -1 */
             while ((nread = ap_get_client_block(r, buf, sizeof(buf))) > 0) {
-                coraza_append_request_body(ctx->transaction,
-                                           (unsigned char *)buf, (int)nread);
+                if (CORAZA_CALL_FAILED(coraza_append_request_body(
+                        ctx->transaction, (unsigned char *)buf, (int)nread))) {
+                    /* Engine error: fail closed rather than skip inspection. */
+                    ctx->intervention_triggered = 1;
+                    return HTTP_INTERNAL_SERVER_ERROR;
+                }
 
                 ret = coraza_process_intervention(ctx->transaction, r, 1);
                 if (ret > 0) {
@@ -178,7 +182,10 @@ coraza_post_read_request(request_rec *r)
                 return HTTP_BAD_REQUEST;
             }
 
-            coraza_process_request_body(ctx->transaction);
+            if (CORAZA_CALL_FAILED(coraza_process_request_body(ctx->transaction))) {
+                ctx->intervention_triggered = 1;
+                return HTTP_INTERNAL_SERVER_ERROR;
+            }
             ctx->phase2_done = 1;
 
             ret = coraza_process_intervention(ctx->transaction, r, 1);
@@ -188,7 +195,10 @@ coraza_post_read_request(request_rec *r)
             }
         } else {
             /* No body to read, still finalize phase 2 */
-            coraza_process_request_body(ctx->transaction);
+            if (CORAZA_CALL_FAILED(coraza_process_request_body(ctx->transaction))) {
+                ctx->intervention_triggered = 1;
+                return HTTP_INTERNAL_SERVER_ERROR;
+            }
             ctx->phase2_done = 1;
 
             ret = coraza_process_intervention(ctx->transaction, r, 1);


### PR DESCRIPTION
Ports coraza-nginx #96/#100/#101. The four body submit/process calls ignored their return values, so a Coraza engine error silently passed the request or response through uninspected (fail-open).

All 7 call sites now fail closed on a non-zero return — request side (phase1 main path + the body_in fallback filter) → 500; response side (filter_out) → a clean 500 if the headers are still delayed, otherwise a reset. The libcoraza ABI this module targets returns non-zero on error and 0 on success, with interruptions reported separately via `coraza_intervention()`, so `!= 0` is the failure test.

No positive test: the engine returns errors only on internal I/O failures, not from anything rule- or request-reachable (malformed input sets variables instead) — same as the nginx fail-closed series. The existing suite guards the condition polarity: a wrong sense would 500 every normal request. 144/0 on event and prefork.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failure handling during request and response body inspection.
  * Inspection errors now fail closed instead of allowing potentially uninspected data to continue.
  * Returns an HTTP 500 error when security processing cannot be completed.
  * Prevents incomplete or already-started responses from continuing after inspection failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->