### PR TITLE
fix: fail closed when transaction creation fails in create_ctx

### DIFF
--- a/src/mod_coraza.c
+++ b/src/mod_coraza.c
@@ -276,6 +276,19 @@ coraza_create_ctx(request_rec *r)
         ctx->transaction = coraza_new_transaction(waf);
     }
 
+    /*
+     * Validate the handle before it is stored or a cleanup is registered.
+     * A zero handle means the engine could not create the transaction; letting
+     * it through would have every later coraza_* call operate on a null handle
+     * (and register a cleanup that frees nothing). Fail closed instead -- the
+     * caller turns a NULL ctx into HTTP 500.
+     */
+    if (ctx->transaction == 0) {
+        ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
+                      "coraza: failed to create transaction");
+        return NULL;
+    }
+
     ap_set_module_config(r->request_config, &coraza_module, ctx);
 
     apr_pool_cleanup_register(r->pool, ctx, coraza_cleanup_transaction,


### PR DESCRIPTION
Ports the create_ctx half of coraza-nginx #95.

`coraza_create_ctx` never checked the handle from `coraza_new_transaction[_with_id]`. A zero handle (engine could not create the transaction) was stored and a cleanup registered, then every later `coraza_*` call ran against a null handle. Now it fails closed: on a zero handle it logs and returns NULL, which the caller already turns into HTTP 500.

The other half of nginx #95 (free the transaction if cleanup registration fails) doesn't apply here — APR's `apr_pool_cleanup_register` returns void and can't fail that way.

No positive test (transaction creation only fails on engine/allocation errors, not anything rule-reachable) — the suite guards the normal path: a wrong check would 500 every request. 144/0 on event and prefork.
