### PR TITLE
fix: guard size_t to int narrowing at the Coraza cgo boundary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -187,6 +187,10 @@ RUN { \
     echo '<Location "/protocol-check">'; \
     echo '    SecRule REQUEST_PROTOCOL "@streq HTTP/1.1" "id:20800,phase:1,deny,status:403,log"'; \
     echo '</Location>'; \
+    echo '# --- Large header inspection (cgo length-narrowing guard must not clip) ---'; \
+    echo '<Location "/header-check">'; \
+    echo '    SecRule REQUEST_HEADERS:X-Test "@contains BOOMHEADER" "id:20810,phase:1,deny,status:403,log"'; \
+    echo '</Location>'; \
     echo '# --- SSE streaming: header delay must be skipped (never sends EOS) ---'; \
     echo 'ScriptAlias "/sse-stream" "/usr/local/apache2/cgi-bin/sse"'; \
     echo 'ScriptAlias "/sse-nearmiss" "/usr/local/apache2/cgi-bin/sse"'; \

--- a/src/mod_coraza.h
+++ b/src/mod_coraza.h
@@ -21,6 +21,7 @@
 #include <apr_strings.h>
 #include <apr_tables.h>
 #include <apr_buckets.h>
+#include <limits.h>
 #include <util_filter.h>
 #include <coraza/coraza.h>
 

--- a/src/mod_coraza_body_in.c
+++ b/src/mod_coraza_body_in.c
@@ -83,6 +83,21 @@ coraza_input_filter(ap_filter_t *f, apr_bucket_brigade *bb,
         }
 
         if (len > 0) {
+            /*
+             * coraza_append_request_body takes an int length; guard the
+             * apr_size_t -> int narrowing so a >INT_MAX bucket cannot wrap to a
+             * bogus length and have the engine inspect the wrong span. Fail
+             * closed.
+             */
+            if (len > INT_MAX) {
+                ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, f->r,
+                              "coraza: request body chunk too large to inspect");
+                ctx->intervention_triggered = 1;
+                ctx->phase2_done = 1;
+                ap_remove_input_filter(f);
+                return APR_EGENERAL;
+            }
+
             if (CORAZA_CALL_FAILED(coraza_append_request_body(ctx->transaction,
                                        (unsigned char *)data, (int)len))) {
                 ctx->intervention_triggered = 1;

--- a/src/mod_coraza_filter_out.c
+++ b/src/mod_coraza_filter_out.c
@@ -258,6 +258,17 @@ coraza_output_filter(ap_filter_t *f, apr_bucket_brigade *bb)
         }
 
         if (len > 0 && ctx->response_body_processable) {
+            /*
+             * coraza_append_response_body takes an int length; guard the
+             * apr_size_t -> int narrowing so a >INT_MAX bucket cannot wrap to a
+             * bogus length and skip inspection. Fail closed.
+             */
+            if (len > INT_MAX) {
+                ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
+                              "coraza: response body chunk too large to inspect");
+                return coraza_fail_closed_response(f, r, ctx, bb);
+            }
+
             if (CORAZA_CALL_FAILED(coraza_append_response_body(ctx->transaction,
                                         (unsigned char *)data, (int)len))) {
                 /* Engine error: fail closed rather than stream uninspected. */

--- a/src/mod_coraza_phase1.c
+++ b/src/mod_coraza_phase1.c
@@ -124,14 +124,31 @@ coraza_post_read_request(request_rec *r)
         telts = (const apr_table_entry_t *)tarr->elts;
 
         for (i = 0; i < tarr->nelts; i++) {
+            size_t name_len, val_len;
+
             if (telts[i].key == NULL) {
                 continue;
             }
+
+            /*
+             * coraza_add_request_header takes int lengths; guard the size_t ->
+             * int narrowing so an oversized header cannot wrap to a bogus
+             * length and slip past inspection. Fail closed.
+             */
+            name_len = strlen(telts[i].key);
+            val_len  = telts[i].val ? strlen(telts[i].val) : 0;
+            if (name_len > INT_MAX || val_len > INT_MAX) {
+                ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
+                              "coraza: request header too long to inspect");
+                ctx->intervention_triggered = 1;
+                return HTTP_INTERNAL_SERVER_ERROR;
+            }
+
             coraza_add_request_header(ctx->transaction,
                                       (char *)telts[i].key,
-                                      (int)strlen(telts[i].key),
+                                      (int)name_len,
                                       (char *)telts[i].val,
-                                      telts[i].val ? (int)strlen(telts[i].val) : 0);
+                                      (int)val_len);
         }
 
         coraza_process_request_headers(ctx->transaction);

--- a/test.sh
+++ b/test.sh
@@ -494,6 +494,15 @@ check_curl "Protocol: HTTP/1.1 matches REQUEST_PROTOCOL" "$URL/protocol-check" 4
 check_curl "Protocol: HTTP/1.0 does not match"           "$URL/protocol-check" 200 --http1.0
 echo ""
 
+echo "--- Large header inspection (length-narrowing guard) ---"
+# A large but legal header must still reach the engine in full: the trigger sits
+# at the very end of ~6 KB of padding, so a clipped length would miss it.
+big_hdr="$(printf 'A%.0s' $(seq 1 6000))BOOMHEADER"
+pad_hdr="$(printf 'A%.0s' $(seq 1 6000))"
+check_curl "Large header: trigger at end is inspected" "$URL/header-check" 403 -H "X-Test: $big_hdr"
+check_curl "Large header: padding only is not clipped" "$URL/header-check" 200 -H "X-Test: $pad_hdr"
+echo ""
+
 echo "--- Response phase tests (3+4) ---"
 check "Phase 3: deny on Content-Type"       "$URL/phase3"                          403
 check "Phase 3: pass no match"              "$URL/phase3-pass"                     200


### PR DESCRIPTION
Ports coraza-nginx #78.

`coraza_add_request_header`, `coraza_append_request_body` and `coraza_append_response_body` take `int` lengths, but the connector passed `size_t`/`apr_size_t` header and body lengths straight through. A length above INT_MAX would wrap to a negative or truncated int, so the engine would inspect the wrong span — a potential bypass or over-read. Added explicit `> INT_MAX` ceilings that fail closed at three boundaries: request headers (phase1), the fallback request-body filter (body_in), and the response body (filter_out).

Not guarded: the phase1 main request-body path reads into an 8 KB stack buffer, so its length is provably bounded — a guard there would be dead code. Response headers are server-generated and bounded (same scoping as nginx #78).

Regression test: a large but legal request header (~6 KB of padding with the trigger at the very end) is still fully inspected → 403, and a padding-only large header is not clipped into a false match → 200. Proves the length refactor doesn't clip legitimate headers. 146/0 on event and prefork.
