### PR TITLE
fix: return the rule status for phase-2/4 interruptions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,14 +12,15 @@ jobs:
   build:
     permissions:
       contents: read
-    name: Build and test (${{ matrix.mpm }} MPM)
+    name: Build and test (${{ matrix.mpm }} MPM, libcoraza ${{ matrix.libcoraza }})
     runs-on: ubuntu-24.04
-    env:
-      # renovate: datasource=github-releases depName=corazawaf/libcoraza
-      LIBCORAZA_VERSION: v1.4.0
     strategy:
       matrix:
         mpm: [event, prefork]
+        # Both coraza_process_* ABIs: v1.4.0 returns 1 on an engine error,
+        # v1.5.0 and later return the tri-state coraza_result_t.
+        # renovate: datasource=github-releases depName=corazawaf/libcoraza
+        libcoraza: [v1.7.0, v1.4.0]
 
     steps:
       - name: Checkout repo
@@ -29,6 +30,7 @@ jobs:
         run: |
           docker build --no-cache \
             --build-arg MPM=${{ matrix.mpm }} \
+            --build-arg LIBCORAZA_VERSION=${{ matrix.libcoraza }} \
             -t coraza-apache-${{ matrix.mpm }} .
 
       - name: Start Apache container
@@ -79,7 +81,7 @@ jobs:
           ~/go/bin/go-ftw run --cloud --config tests/ftw-crs.yml -d /tmp/coreruleset-${CRS_VERSION}/tests/regression/tests/
 
       - name: Extract module artifact
-        if: matrix.mpm == 'event'
+        if: matrix.mpm == 'event' && matrix.libcoraza == 'v1.7.0'
         run: |
           docker cp \
             coraza-apache-${{ matrix.mpm }}:/usr/local/apache2/modules/mod_coraza.so \
@@ -90,7 +92,7 @@ jobs:
         run: docker stop coraza-apache-${{ matrix.mpm }} || true
 
       - name: Upload module artifact
-        if: matrix.mpm == 'event'
+        if: matrix.mpm == 'event' && matrix.libcoraza == 'v1.7.0'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: mod_coraza-linux-amd64

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     env:
       # renovate: datasource=github-releases depName=corazawaf/libcoraza
-      LIBCORAZA_VERSION: v1.4.0
+      LIBCORAZA_VERSION: v1.7.0
     strategy:
       matrix:
         arch: [amd64, arm64]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN set -eux; \
         bash \
         make
 
-ARG LIBCORAZA_VERSION=v1.4.0
+ARG LIBCORAZA_VERSION=v1.7.0
 
 RUN set -eux; \
     wget https://github.com/corazawaf/libcoraza/tarball/${LIBCORAZA_VERSION} -O /tmp/libcoraza.tar.gz; \

--- a/src/mod_coraza.h
+++ b/src/mod_coraza.h
@@ -98,9 +98,9 @@ typedef struct {
  * Non-zero when the loaded libcoraza returns a tri-state from the
  * coraza_process_* calls: CORAZA_ERROR (-1), CORAZA_OK (0),
  * CORAZA_INTERRUPTION (1). Before 1.5 those calls returned 1 on an engine
- * error and never signalled an interruption. Detected in coraza_dl_open() by
- * probing for a symbol only present in 1.5+, because the ABI is picked when
- * libcoraza.so is dlopen'd, not when this module is compiled.
+ * error and never signalled an interruption. Determined in coraza_dl_open()
+ * from the loaded library rather than from the headers this module was built
+ * against, because the ABI is picked when libcoraza.so is dlopen'd.
  */
 extern int coraza_tristate_abi;
 

--- a/src/mod_coraza.h
+++ b/src/mod_coraza.h
@@ -86,13 +86,39 @@ typedef struct {
 #endif
 
 /*
- * Fail-closed check for the body submit/process calls. The libcoraza ABI this
- * module targets (< 1.6) returns non-zero on an engine error and 0 on success;
- * interruptions are reported separately via coraza_intervention(). A non-zero
- * return therefore means inspection could not complete, and the request or
- * response must be failed closed rather than passed through uninspected.
+ * Fail-closed check for the body submit calls (coraza_append_*, coraza_add_*).
+ * These return 0 on success and 1 on an engine error and never signal an
+ * interruption, so any non-zero return means inspection could not complete and
+ * the request or response must be failed closed rather than passed through
+ * uninspected.
  */
 #define CORAZA_CALL_FAILED(rc) ((rc) != 0)
+
+/*
+ * Non-zero when the loaded libcoraza returns a tri-state from the
+ * coraza_process_* calls: CORAZA_ERROR (-1), CORAZA_OK (0),
+ * CORAZA_INTERRUPTION (1). Before 1.5 those calls returned 1 on an engine
+ * error and never signalled an interruption. Detected in coraza_dl_open() by
+ * probing for a symbol only present in 1.5+, because the ABI is picked when
+ * libcoraza.so is dlopen'd, not when this module is compiled.
+ */
+extern int coraza_tristate_abi;
+
+/*
+ * Fail-closed check for the coraza_process_* calls. On the tri-state ABI only
+ * CORAZA_ERROR is a failure: an interruption is the normal outcome of a deny
+ * rule and must fall through to coraza_process_intervention() so the rule's
+ * own status is returned instead of 500. On the older ABI any non-zero return
+ * is an engine error. Written as < 0 rather than == CORAZA_ERROR so the module
+ * still builds against pre-1.5 headers, which do not declare the enum, and as
+ * a function rather than a macro because every caller passes a call
+ * expression that must be evaluated exactly once.
+ */
+static inline int
+coraza_process_failed(int rc)
+{
+    return coraza_tristate_abi ? rc < 0 : rc != 0;
+}
 
 /* Per-request context */
 typedef struct {

--- a/src/mod_coraza_body_in.c
+++ b/src/mod_coraza_body_in.c
@@ -50,7 +50,7 @@ coraza_input_filter(ap_filter_t *f, apr_bucket_brigade *bb,
 
         if (APR_BUCKET_IS_EOS(b)) {
             /* End of request body -- process it */
-            if (CORAZA_CALL_FAILED(coraza_process_request_body(ctx->transaction))) {
+            if (coraza_process_failed(coraza_process_request_body(ctx->transaction))) {
                 /* Engine error: fail closed rather than pass uninspected. */
                 ctx->intervention_triggered = 1;
                 ctx->phase2_done = 1;

--- a/src/mod_coraza_dl.c
+++ b/src/mod_coraza_dl.c
@@ -45,6 +45,7 @@ typedef int                  (*fn_coraza_process_logging)(coraza_transaction_t);
 typedef int                  (*fn_coraza_update_status_code)(coraza_transaction_t, int);
 typedef int                  (*fn_coraza_add_get_args)(coraza_transaction_t, char *, char *);
 typedef int                  (*fn_coraza_is_response_body_processable)(coraza_transaction_t);
+typedef int                  (*fn_coraza_version_num)(void);
 
 /* ------------------------------------------------------------------ */
 /* Static function pointers -- set once by coraza_dl_open()            */
@@ -107,6 +108,10 @@ int coraza_tristate_abi;
 int
 coraza_dl_open(server_rec *s)
 {
+    fn_coraza_version_num version_num;
+    int version;
+    char version_str[32];
+
     if (dl_handle != NULL) {
         return OK;
     }
@@ -151,19 +156,32 @@ coraza_dl_open(server_rec *s)
            coraza_is_response_body_processable);
 
     /*
-     * coraza_add_request_headers appeared in libcoraza 1.5, the same release
-     * that turned the coraza_process_* return value into a tri-state. Probe
-     * for it to pick the right reading of that value (see
-     * coraza_process_failed) -- it is not used otherwise, and its absence is
-     * not an error.
+     * Pick how to read the coraza_process_* return value (see
+     * coraza_process_failed). coraza_version_num() reports the version of the
+     * library that actually got loaded, so it is the explicit test -- but it
+     * only exists from libcoraza 1.7.0, and its absence spans both ABIs. Fall
+     * back to probing for coraza_add_request_headers, which first appears in
+     * 1.5, the same release that introduced the tri-state. Neither symbol is
+     * required and neither is used for anything else.
      */
-    coraza_tristate_abi =
-        (dynlib_sym(dl_handle, "coraza_add_request_headers") != NULL);
+    *(void **)(&version_num) = dynlib_sym(dl_handle, "coraza_version_num");
+
+    if (version_num != NULL) {
+        version = version_num();
+        coraza_tristate_abi = (version >= 10500);
+        apr_snprintf(version_str, sizeof(version_str), "%d.%d.%d",
+                     version / 10000, version / 100 % 100, version % 100);
+    } else {
+        coraza_tristate_abi =
+            (dynlib_sym(dl_handle, "coraza_add_request_headers") != NULL);
+        apr_cpystrn(version_str, "< 1.7.0", sizeof(version_str));
+    }
 
     ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, s,
-                 "coraza: %s loaded via dynlib_open (libcoraza %s ABI)",
-                 CORAZA_DYNLIB_BASENAME DYNLIB_EXT,
-                 coraza_tristate_abi ? ">= 1.5" : "< 1.5");
+                 "coraza: %s loaded via dynlib_open "
+                 "(libcoraza %s, %s coraza_process_* ABI)",
+                 CORAZA_DYNLIB_BASENAME DYNLIB_EXT, version_str,
+                 coraza_tristate_abi ? "tri-state" : "pre-1.5");
 
     return OK;
 }

--- a/src/mod_coraza_dl.c
+++ b/src/mod_coraza_dl.c
@@ -81,6 +81,8 @@ static fn_coraza_is_response_body_processable dl_is_response_body_processable;
 
 static dynlib_t dl_handle;
 
+int coraza_tristate_abi;
+
 /* ------------------------------------------------------------------ */
 /* Resolve one symbol -- returns HTTP_INTERNAL_SERVER_ERROR on failure  */
 /* ------------------------------------------------------------------ */
@@ -148,9 +150,20 @@ coraza_dl_open(server_rec *s)
     DL_SYM(dl_is_response_body_processable,
            coraza_is_response_body_processable);
 
+    /*
+     * coraza_add_request_headers appeared in libcoraza 1.5, the same release
+     * that turned the coraza_process_* return value into a tri-state. Probe
+     * for it to pick the right reading of that value (see
+     * coraza_process_failed) -- it is not used otherwise, and its absence is
+     * not an error.
+     */
+    coraza_tristate_abi =
+        (dynlib_sym(dl_handle, "coraza_add_request_headers") != NULL);
+
     ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, s,
-                 "coraza: %s loaded via dynlib_open",
-                 CORAZA_DYNLIB_BASENAME DYNLIB_EXT);
+                 "coraza: %s loaded via dynlib_open (libcoraza %s ABI)",
+                 CORAZA_DYNLIB_BASENAME DYNLIB_EXT,
+                 coraza_tristate_abi ? ">= 1.5" : "< 1.5");
 
     return OK;
 }

--- a/src/mod_coraza_filter_out.c
+++ b/src/mod_coraza_filter_out.c
@@ -297,7 +297,7 @@ coraza_output_filter(ap_filter_t *f, apr_bucket_brigade *bb)
 
     if (has_eos) {
         /* Process complete response body */
-        if (CORAZA_CALL_FAILED(coraza_process_response_body(ctx->transaction))) {
+        if (coraza_process_failed(coraza_process_response_body(ctx->transaction))) {
             return coraza_fail_closed_response(f, r, ctx, bb);
         }
 

--- a/src/mod_coraza_phase1.c
+++ b/src/mod_coraza_phase1.c
@@ -199,7 +199,7 @@ coraza_post_read_request(request_rec *r)
                 return HTTP_BAD_REQUEST;
             }
 
-            if (CORAZA_CALL_FAILED(coraza_process_request_body(ctx->transaction))) {
+            if (coraza_process_failed(coraza_process_request_body(ctx->transaction))) {
                 ctx->intervention_triggered = 1;
                 return HTTP_INTERNAL_SERVER_ERROR;
             }
@@ -212,7 +212,7 @@ coraza_post_read_request(request_rec *r)
             }
         } else {
             /* No body to read, still finalize phase 2 */
-            if (CORAZA_CALL_FAILED(coraza_process_request_body(ctx->transaction))) {
+            if (coraza_process_failed(coraza_process_request_body(ctx->transaction))) {
                 ctx->intervention_triggered = 1;
                 return HTTP_INTERNAL_SERVER_ERROR;
             }


### PR DESCRIPTION
Fixes #26.

Since v0.20.0, every phase-2 and phase-4 rule interruption is answered with 500 instead of the rule's own status when the module runs against libcoraza v1.5.0 or later. Phase 1 is unaffected, so the module looks healthy: traffic is proxied, `DetectionOnly` detects, audit logs are written, and a phase-1 `deny,status:403` returns 403. Under CRS anomaly scoring the broken path covers every block, since rule `949110` is phase 2.

libcoraza 1.5 turned the `coraza_process_*` return value into a tri-state:

```c
typedef enum coraza_result_t {
	CORAZA_ERROR = -1,
	CORAZA_OK = 0,
	CORAZA_INTERRUPTION = 1,
} coraza_result_t;
```

The fail-closed guards added in 70afb20 test it with `CORAZA_CALL_FAILED(rc) ((rc) != 0)`, so a normal deny reads as an engine error, `ctx->intervention_triggered` is set, `HTTP_INTERNAL_SERVER_ERROR` / `APR_EGENERAL` is returned, and `coraza_process_intervention()` never runs to emit the rule's status.

## How the return value is read

```c
/* mod_coraza.h */
static inline int
coraza_process_failed(int rc)
{
    return coraza_tristate_abi ? rc < 0 : rc != 0;
}
```

applied at the four `coraza_process_*_body` sites in `mod_coraza_phase1.c`, `mod_coraza_body_in.c` and `mod_coraza_filter_out.c`.

Two details worth calling out:

- **A function, not a macro.** Every call site passes `coraza_process_request_body(...)` as the argument and the branch reads `rc` twice, so as a macro this would call into the engine twice per request.
- **`< 0` rather than `== CORAZA_ERROR`.** The enum does not exist in pre-1.5 headers, so naming it would break building against v1.4.0, which is still supported.

`CORAZA_CALL_FAILED` stays `!= 0` for the `coraza_append_*` and `coraza_add_*` calls: those return a plain `1` on error in every version and never signal an interruption. Fail-closed behaviour is preserved on both ABIs.

## How the ABI is detected

At load, not at compile time. The module `dlopen`s libcoraza in `child_init` and resolves every symbol at runtime, so the ABI is decided when `libcoraza.so` is loaded rather than when the module is compiled. `coraza.h` also carries no version macro before 1.7.0, and the preprocessor cannot test for a function declaration or an enum constant.

corazawaf/libcoraza#125 added `coraza_version_num()`, released in libcoraza v1.7.0, which reports the version of the library actually loaded. That is the explicit test — but it only exists from 1.7.0, and its absence spans both ABIs, so it cannot stand alone. `coraza_add_request_headers` first appears in 1.5, the same release as the tri-state, and covers the 1.4 through 1.6 range:

```c
/* mod_coraza_dl.c, in coraza_dl_open() */
*(void **)(&version_num) = dynlib_sym(dl_handle, "coraza_version_num");

if (version_num != NULL) {
    version = version_num();
    coraza_tristate_abi = (version >= 10500);
    ...
} else {
    coraza_tristate_abi =
        (dynlib_sym(dl_handle, "coraza_add_request_headers") != NULL);
    ...
}
```

Neither symbol is required and neither is used for anything else. The startup log line now names the version and the ABI.

## CI and the pinned version

`build.yml` set `LIBCORAZA_VERSION` but never passed it to `docker build`, so every run used the Dockerfile default and no run exercised the ABI this bug lives in. It is now passed, and is a matrix axis over `v1.7.0` and `v1.4.0` — four jobs with the existing MPM axis. The module artifact is gated on the libcoraza version too, so those jobs do not race to upload the same artifact name.

`Dockerfile` and `package.yml` move from `v1.4.0` to `v1.7.0`. Both ABIs are supported, so this only changes which one the images and packages ship with.

## Testing

Docker images built at each `LIBCORAZA_VERSION`, Apache 2.4 event MPM, CRS 4.23.0, full `test.sh` with `--container`:

| build → runtime library | startup log | phase2 | phase4 | full `test.sh` |
|---|---|---|---|---|
| v1.6.0 → v1.6.0, before this PR | — | 500 | 500 | 98 passed, 48 failed |
| v1.7.0 → v1.7.0 | `libcoraza 1.7.0, tri-state` | 403 | 403 | 139 passed, 7 failed |
| v1.4.0 → v1.4.0 | `libcoraza < 1.7.0, pre-1.5` | 403 | 403 | 139 passed, 7 failed |
| v1.7.0 headers → v1.6.0 `.so` | `libcoraza < 1.7.0, tri-state` | 403 | 403 | — |

The last row is the fallback path: a library with the tri-state but no version accessor. It is also the case a compile-time test gets wrong, since the header and the loaded library disagree.

The 7 remaining failures are identical in every configuration and unrelated to this change: they are the `413` body-limit tests, failing because `test.sh` generates oversize bodies with `cat /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c N` and BSD `tr` aborts on the first illegal byte sequence (200 bytes requested, 27 produced). An artifact of running the suite from a macOS host; CI on Linux is not affected.

The predicate's truth table was also checked directly for both flag values, including the fail-closed cases (`-1` on the tri-state ABI, `1` on pre-1.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected request and response processing so deny-rule interventions are handled properly instead of being reported as engine errors.
  * Preserved fail-closed behavior when body inspection encounters a genuine processing failure.

* **Compatibility**
  * Added automatic detection for supported libcoraza ABI versions, improving interoperability with older and newer releases.
  * Updated processing-result handling to interpret responses correctly across ABI versions.

* **Testing**
  * Expanded build and test coverage across multiple libcoraza versions and server configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->