### PR TITLE
docs: drop EOL 25.10 (questing) from PPA build targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ sudo apt update
 sudo apt install libapache2-mod-coraza
 ```
 
-This pulls in libcoraza automatically. Built for Ubuntu 22.04 (jammy), 24.04 (noble), 25.10 (questing), 26.04 (resolute) and 26.10 (stonking).
+This pulls in libcoraza automatically. Built for Ubuntu 22.04 (jammy), 24.04 (noble), 26.04 (resolute) and 26.10 (stonking).
 
 ## Build
 


### PR DESCRIPTION
Ubuntu 25.10 (questing) reached end of life in 2026-07 and is no longer a PPA build target. Drop it from the supported-versions line; jammy/noble/resolute/stonking are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Ubuntu PPA installation instructions to support Ubuntu 26.04 (Resolute) and 26.10 (Stonking).
  - Removed Ubuntu 25.10 (Questing) from the listed supported builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->