### PR TITLE
chore: pin libcoraza floor to 1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This pulls in libcoraza automatically. Built for Ubuntu 22.04 (jammy), 24.04 (no
 
 ## Build
 
-Requires libcoraza >= 1.4.0 headers at compile time and the shared library at runtime.
+Requires libcoraza >= 1.6 headers at compile time and the shared library at runtime.
 The module is not linked against libcoraza -- it loads it via dlopen()
 after fork to avoid Go runtime deadlocks.
 

--- a/debian/control
+++ b/debian/control
@@ -4,14 +4,14 @@ Priority: optional
 Maintainer: Pierre Pomes <pierre.pomes@gmail.com>
 Build-Depends: debhelper-compat (= 13),
                apache2-dev,
-               libcoraza-dev
+               libcoraza-dev (>= 1.6)
 Standards-Version: 4.7.0
 Homepage: https://github.com/corazawaf/coraza-apache
 Rules-Requires-Root: no
 
 Package: libapache2-mod-coraza
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, libcoraza1
+Depends: ${misc:Depends}, ${shlibs:Depends}, libcoraza1 (>= 1.6)
 Description: Coraza WAF module for Apache HTTPD
  Coraza is an open-source Web Application Firewall (WAF) engine.
  This module integrates the Coraza WAF with the Apache HTTP Server,


### PR DESCRIPTION
`debian/control` declared no libcoraza floor (`Depends: libcoraza1` was unversioned). Pin both to `>= 1.6` to match the connector's supported floor and the coraza-nginx packaging.

The runtime ABI detection from #27 stays — the module still adapts to whatever libcoraza is loaded; this just declares the packaged floor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the underlying security components to support the latest available Coraza capabilities.
  * No user-facing functionality or interface changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->