### PR TITLE
refactor: require libcoraza >= 1.7, gate on coraza_version_num()

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,10 @@ jobs:
     strategy:
       matrix:
         mpm: [event, prefork]
-        # Both coraza_process_* ABIs: v1.4.0 returns 1 on an engine error,
-        # v1.5.0 and later return the tri-state coraza_result_t.
+        # The module requires libcoraza >= 1.7.0 (coraza_dl_open gates on
+        # coraza_version_num); older releases are rejected at startup.
         # renovate: datasource=github-releases depName=corazawaf/libcoraza
-        libcoraza: [v1.7.0, v1.4.0]
+        libcoraza: [v1.7.0]
 
     steps:
       - name: Checkout repo

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ This pulls in libcoraza automatically. Built for Ubuntu 22.04 (jammy), 24.04 (no
 
 ## Build
 
-Requires libcoraza >= 1.7 headers at compile time and the shared library at runtime.
+Requires libcoraza >= 1.7 for both the headers at compile time and the shared
+library at runtime -- the module gates on `coraza_version_num()` at startup and
+refuses to load against an older runtime library.
 The module is not linked against libcoraza -- it loads it via dlopen()
 after fork to avoid Go runtime deadlocks.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This pulls in libcoraza automatically. Built for Ubuntu 22.04 (jammy), 24.04 (no
 
 ## Build
 
-Requires libcoraza >= 1.6 headers at compile time and the shared library at runtime.
+Requires libcoraza >= 1.7 headers at compile time and the shared library at runtime.
 The module is not linked against libcoraza -- it loads it via dlopen()
 after fork to avoid Go runtime deadlocks.
 

--- a/debian/control
+++ b/debian/control
@@ -4,14 +4,14 @@ Priority: optional
 Maintainer: Pierre Pomes <pierre.pomes@gmail.com>
 Build-Depends: debhelper-compat (= 13),
                apache2-dev,
-               libcoraza-dev (>= 1.6)
+               libcoraza-dev (>= 1.7)
 Standards-Version: 4.7.0
 Homepage: https://github.com/corazawaf/coraza-apache
 Rules-Requires-Root: no
 
 Package: libapache2-mod-coraza
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, libcoraza1 (>= 1.6)
+Depends: ${misc:Depends}, ${shlibs:Depends}, libcoraza1 (>= 1.7)
 Description: Coraza WAF module for Apache HTTPD
  Coraza is an open-source Web Application Firewall (WAF) engine.
  This module integrates the Coraza WAF with the Apache HTTP Server,

--- a/src/mod_coraza.h
+++ b/src/mod_coraza.h
@@ -95,29 +95,20 @@ typedef struct {
 #define CORAZA_CALL_FAILED(rc) ((rc) != 0)
 
 /*
- * Non-zero when the loaded libcoraza returns a tri-state from the
- * coraza_process_* calls: CORAZA_ERROR (-1), CORAZA_OK (0),
- * CORAZA_INTERRUPTION (1). Before 1.5 those calls returned 1 on an engine
- * error and never signalled an interruption. Determined in coraza_dl_open()
- * from the loaded library rather than from the headers this module was built
- * against, because the ABI is picked when libcoraza.so is dlopen'd.
- */
-extern int coraza_tristate_abi;
-
-/*
- * Fail-closed check for the coraza_process_* calls. On the tri-state ABI only
- * CORAZA_ERROR is a failure: an interruption is the normal outcome of a deny
- * rule and must fall through to coraza_process_intervention() so the rule's
- * own status is returned instead of 500. On the older ABI any non-zero return
- * is an engine error. Written as < 0 rather than == CORAZA_ERROR so the module
- * still builds against pre-1.5 headers, which do not declare the enum, and as
- * a function rather than a macro because every caller passes a call
- * expression that must be evaluated exactly once.
+ * Fail-closed check for the coraza_process_* calls. coraza_dl_open() requires
+ * libcoraza >= 1.7.0, which uses the tri-state coraza_result_t contract:
+ * CORAZA_ERROR (-1), CORAZA_OK (0), CORAZA_INTERRUPTION (1). Only CORAZA_ERROR
+ * is a failure -- an interruption is the normal outcome of a deny rule and must
+ * fall through to coraza_process_intervention() so the rule's own status is
+ * returned instead of 500. Written as < 0 rather than == CORAZA_ERROR so the
+ * module still builds against headers that do not name the enum, and as a
+ * function rather than a macro because every caller passes a call expression
+ * that must be evaluated exactly once.
  */
 static inline int
 coraza_process_failed(int rc)
 {
-    return coraza_tristate_abi ? rc < 0 : rc != 0;
+    return rc < 0;
 }
 
 /* Per-request context */

--- a/src/mod_coraza_dl.c
+++ b/src/mod_coraza_dl.c
@@ -82,8 +82,6 @@ static fn_coraza_is_response_body_processable dl_is_response_body_processable;
 
 static dynlib_t dl_handle;
 
-int coraza_tristate_abi;
-
 /* ------------------------------------------------------------------ */
 /* Resolve one symbol -- returns HTTP_INTERNAL_SERVER_ERROR on failure  */
 /* ------------------------------------------------------------------ */
@@ -156,32 +154,29 @@ coraza_dl_open(server_rec *s)
            coraza_is_response_body_processable);
 
     /*
-     * Pick how to read the coraza_process_* return value (see
-     * coraza_process_failed). coraza_version_num() reports the version of the
-     * library that actually got loaded, so it is the explicit test -- but it
-     * only exists from libcoraza 1.7.0, and its absence spans both ABIs. Fall
-     * back to probing for coraza_add_request_headers, which first appears in
-     * 1.5, the same release that introduced the tri-state. Neither symbol is
-     * required and neither is used for anything else.
+     * Gate on the loaded library's version. coraza_version_num() first appears
+     * in 1.7.0 and reports the version of the library actually dlopen'd -- the
+     * authoritative test for a module that resolves everything at runtime. From
+     * 1.5 the coraza_process_* calls use the tri-state coraza_result_t contract
+     * that coraza_process_failed() assumes (< 0 == error, 1 == interruption).
+     * A library that does not export coraza_version_num(), or reports < 1.7.0,
+     * is unsupported: fail coraza_dl_open() so the worker refuses to start
+     * (fail closed) rather than mis-read an interruption as an engine error.
      */
     *(void **)(&version_num) = dynlib_sym(dl_handle, "coraza_version_num");
-
-    if (version_num != NULL) {
-        version = version_num();
-        coraza_tristate_abi = (version >= 10500);
-        apr_snprintf(version_str, sizeof(version_str), "%d.%d.%d",
-                     version / 10000, version / 100 % 100, version % 100);
-    } else {
-        coraza_tristate_abi =
-            (dynlib_sym(dl_handle, "coraza_add_request_headers") != NULL);
-        apr_cpystrn(version_str, "< 1.7.0", sizeof(version_str));
+    version = version_num != NULL ? version_num() : 0;
+    if (version < 10700) {
+        ap_log_error(APLOG_MARK, APLOG_EMERG, 0, s,
+                     "coraza: libcoraza >= 1.7.0 required, but the loaded "
+                     "library does not report a compatible version");
+        return HTTP_INTERNAL_SERVER_ERROR;
     }
+    apr_snprintf(version_str, sizeof(version_str), "%d.%d.%d",
+                 version / 10000, version / 100 % 100, version % 100);
 
     ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, s,
-                 "coraza: %s loaded via dynlib_open "
-                 "(libcoraza %s, %s coraza_process_* ABI)",
-                 CORAZA_DYNLIB_BASENAME DYNLIB_EXT, version_str,
-                 coraza_tristate_abi ? "tri-state" : "pre-1.5");
+                 "coraza: %s loaded via dynlib_open (libcoraza %s)",
+                 CORAZA_DYNLIB_BASENAME DYNLIB_EXT, version_str);
 
     return OK;
 }


### PR DESCRIPTION
Simplifies the ABI handling from #27 now that libcoraza exposes `coraza_version_num()` (1.7.0). Drops libcoraza 1.4 support.

**Before (#27):** `coraza_dl_open` detected the ABI at runtime with a two-way probe — call `coraza_version_num()` if present, else fall back to probing `coraza_add_request_headers` — and `coraza_process_failed()` branched on a `coraza_tristate_abi` flag (`< 0` vs `!= 0`).

**After:** `coraza_dl_open` gates on the loaded library's version — `coraza_version_num()` must resolve and report `>= 1.7.0`, otherwise the load fails and the worker refuses to start (fail closed). Since the library is then guaranteed tri-state, `coraza_process_failed()` is just `rc < 0`, and the `coraza_tristate_abi` flag and the symbol-probe fallback are gone.

Why a runtime gate rather than build-time: the module `dlopen`s libcoraza, so the loaded `.so` is what matters — `version_num()` checks the actual library, which a build-time check can't.

- `debian/control` + README → libcoraza `>= 1.7`
- build.yml: drop the `v1.4.0` matrix cell (an old library is now rejected at startup)

**Tested:** against 1.7.0, event + prefork suites 146/0, phase-2/4 denies return the rule status (403), gate accepts. Against 1.6.0, the gate rejects cleanly (`emerg: libcoraza >= 1.7.0 required`, module disabled) — fail closed, no crash.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Updated the required libcoraza version to 1.7 or newer for builds and Debian packages.
  * The module now verifies that the runtime library meets the minimum supported version before loading.

* **Bug Fixes**
  * Improved handling of request-processing interruptions and failures to ensure interventions are handled correctly.

* **Documentation**
  * Updated build requirements and runtime compatibility information in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->