### PR TITLE
release: prepare 0.21.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+libapache2-mod-coraza (0.21.0-1) unstable; urgency=low
+
+  * New upstream release 0.21.0.
+  * Require libcoraza >= 1.7.0; support for older libcoraza is dropped. The
+    module gates on coraza_version_num() at startup and refuses to load
+    against an older shared library, and always uses the tri-state
+    coraza_result_t return contract.
+
+ -- Pierre Pomes <pierre.pomes@gmail.com>  Sat, 29 Aug 2026 12:00:00 +0000
+
 libapache2-mod-coraza (0.20.0-1) unstable; urgency=low
 
   * New upstream release 0.20.0. Version aligned with the coraza-nginx


### PR DESCRIPTION
Cuts 0.21.0 and prepares the Debian packaging changelog.

**Why a release:** the libcoraza >= 1.7 requirement (drop of 1.4 support, gate on `coraza_version_num()`) landed as a `refactor:` commit, which does not trigger release-please. This carries `Release-As: 0.21.0` so a release is actually cut, and adds the matching `debian/changelog` entry.

**Version:** minor bump (0.20 → 0.21) — requiring libcoraza >= 1.7 is a breaking change for anyone on an older library.

After merge, merging release-please's PR tags v0.21.0; then the PPA is rebuilt against libcoraza 1.7.
